### PR TITLE
Minor fix from bitshares pr 689

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -251,7 +251,9 @@ void database::reindex( fc::path data_dir )
 void database::wipe(const fc::path& data_dir, bool include_blocks)
 {
    ilog("Wiping database", ("include_blocks", include_blocks));
-   close();
+   if (_opened) {
+     close();
+   }
    object_database::wipe(data_dir);
    if( include_blocks )
       fc::remove_all( data_dir / "database" );
@@ -298,6 +300,8 @@ void database::close(bool rewind)
          _block_id_to_block.close();
 
       _fork_db.reset();
+
+      _opened = false;
    }
    FC_CAPTURE_AND_RETHROW()
 }
@@ -664,6 +668,7 @@ bool database::_push_block(const signed_block& new_block)
          else
             return false;
       }
+      _opened = true;
    }
 
    try

--- a/libraries/chain/include/muse/chain/database.hpp
+++ b/libraries/chain/include/muse/chain/database.hpp
@@ -465,5 +465,14 @@ namespace muse { namespace chain {
          flat_map<uint32_t,block_id_type>  _checkpoints;
 
          node_property_object              _node_property_object;
+
+         /**
+          * Whether database is successfully opened or not.
+          *
+          * The database is considered open when there's no exception
+          * or assertion fail during database::open() method, and
+          * database::close() has not been called, or failed during execution.
+          */
+         bool                              _opened = false;
    };
 } }


### PR DESCRIPTION
Prevents creation of empty object_database in current directory when --replay or --resync is used.