### PR TITLE
Create plugin for evaluating custom_json operations

### DIFF
--- a/libraries/plugins/custom_tags/CMakeLists.txt
+++ b/libraries/plugins/custom_tags/CMakeLists.txt
@@ -1,0 +1,18 @@
+file(GLOB HEADERS "include/muse/custom_tags/*.hpp")
+
+add_library( muse_custom_tags
+             custom_tags.cpp
+             custom_tags_api.cpp
+           )
+
+target_link_libraries( muse_custom_tags muse_chain muse_app )
+target_include_directories( muse_custom_tags
+                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+
+install( TARGETS
+   muse_custom_tags
+
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib
+)

--- a/libraries/plugins/custom_tags/custom_tags.cpp
+++ b/libraries/plugins/custom_tags/custom_tags.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018 PeerTracks, Inc., and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <muse/custom_tags/custom_tags_api.hpp>
+
+namespace muse { namespace custom_tags {
+
+namespace detail {
+
+class custom_tags_impl {
+public:
+   custom_tags_impl( custom_tags_plugin& _plugin )
+      : _self( _plugin ) {}
+
+   ~custom_tags_impl() {}
+
+   muse::chain::database& database() { return _self.database(); }
+
+   void on_operation( const muse::chain::operation_object& op_obj );
+
+   custom_tags_plugin& _self;
+   custom_tags_index*  cti;
+};
+
+void custom_tags_impl::on_operation( const muse::chain::operation_object& op_obj ) {
+    // FIXME
+}
+
+} // detail
+
+custom_tags_plugin::custom_tags_plugin()
+   : my( new detail::custom_tags_impl(*this) ) {}
+
+custom_tags_plugin::~custom_tags_plugin() {}
+
+void custom_tags_plugin::plugin_set_program_options(
+   boost::program_options::options_description& command_line_options,
+   boost::program_options::options_description& config_file_options)
+{
+   command_line_options.add_options()
+         ;
+   config_file_options.add(command_line_options);
+}
+
+std::string custom_tags_plugin::plugin_name()const
+{
+   return "custom_tags";
+}
+
+void custom_tags_plugin::plugin_initialize(const boost::program_options::variables_map& options)
+{ try {
+   ilog("custom_tags plugin: plugin_initialize() begin");
+
+   database().post_apply_operation.connect( [this]( const muse::chain::operation_object& op ){ my->on_operation(op); } );
+   my->cti = database().add_index< primary_index< custom_tags_index > >();
+
+   ilog("custom_tags plugin: plugin_initialize() end");
+} FC_LOG_AND_RETHROW() }
+
+void custom_tags_plugin::plugin_startup() {
+   app().register_api_factory< custom_tags_api >( "custom_tags_api" );
+}
+
+void custom_tags_plugin::plugin_shutdown() { /* Must override pure virtual method */ }
+
+} } // namespace muse::custom_tags
+
+MUSE_DEFINE_PLUGIN( custom_tags, muse::custom_tags::custom_tags_plugin )

--- a/libraries/plugins/custom_tags/custom_tags.cpp
+++ b/libraries/plugins/custom_tags/custom_tags.cpp
@@ -76,7 +76,7 @@ std::set<std::string> custom_tags_impl::get_accounts( const fc::variant_object& 
 
 void custom_tags_impl::set_labels( const std::string& tagger, const std::string& label, std::set<std::string>& names )
 {
-   auto& idx = cti->indices().get<by_all>();
+   auto& idx = cti->indices().get<by_tagger>();
    auto itr = idx.lower_bound( boost::make_tuple( tagger, label, "" ) );
    while( itr != idx.end() && itr->tagger == tagger && itr->tag == label )
    {
@@ -102,7 +102,7 @@ void custom_tags_impl::set_labels( const std::string& tagger, const std::string&
 
 void custom_tags_impl::add_labels( const std::string& tagger, const std::string& label, const std::set<std::string>& names )
 {
-   auto& idx = cti->indices().get<by_all>();
+   auto& idx = cti->indices().get<by_tagger>();
    for( const std::string& name : names )
    {
       auto itr = idx.find( boost::make_tuple( tagger, label, name ) );
@@ -117,7 +117,7 @@ void custom_tags_impl::add_labels( const std::string& tagger, const std::string&
 
 void custom_tags_impl::remove_labels( const std::string& tagger, const std::string& label, const std::set<std::string>& names )
 {
-   auto& idx = cti->indices().get<by_all>();
+   auto& idx = cti->indices().get<by_tagger>();
    for( const std::string& name : names )
    {
       auto itr = idx.find( boost::make_tuple( tagger, label, name ) );

--- a/libraries/plugins/custom_tags/custom_tags_api.cpp
+++ b/libraries/plugins/custom_tags/custom_tags_api.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018 PeerTracks, Inc., and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <muse/app/api_context.hpp>
+#include <muse/app/application.hpp>
+
+#include <muse/custom_tags/custom_tags_api.hpp>
+
+namespace muse { namespace custom_tags {
+
+namespace detail {
+
+class custom_tags_api_impl
+{
+public:
+   custom_tags_api_impl( muse::app::application& _app ) : app( _app ) {}
+
+   std::shared_ptr< muse::custom_tags::custom_tags_plugin > get_plugin()
+   {
+      return app.get_plugin< custom_tags_plugin >( "custom_tags" );
+   }
+
+   bool is_tagged( const std::string& user, const std::string& tagged_by, const std::string& tag ) const;
+   const fc::optional<std::set<std::string>>& list_checked_tags()const;
+   const fc::optional<std::set<std::string>>& list_checked_taggers()const;
+   std::vector<tagging> list_tags( const std::string& filter_tagger,
+                                   const std::string& filter_tag,
+                                   const std::string& filter_taggee,
+                                   const std::string& start_tagger,
+                                   const std::string& start_tag,
+                                   const std::string& start_taggee )const;
+
+private:
+   muse::app::application& app;
+};
+
+bool custom_tags_api_impl::is_tagged( const std::string& user, const std::string& tagged_by, const std::string& tag ) const
+{
+   return false; // FIXME
+}
+
+static const fc::optional<std::set<std::string>> EMPTY;
+
+const fc::optional<std::set<std::string>>& custom_tags_api_impl::list_checked_tags()const
+{
+   return EMPTY; // FIXME
+}
+
+const fc::optional<std::set<std::string>>& custom_tags_api_impl::list_checked_taggers()const
+{
+   return EMPTY; // FIXME
+}
+
+std::vector<tagging> custom_tags_api_impl::list_tags( const std::string& filter_tagger,
+                                      const std::string& filter_tag,
+                                      const std::string& filter_taggee,
+                                      const std::string& start_tagger,
+                                      const std::string& start_tag,
+                                      const std::string& start_taggee )const
+{
+   return std::vector<tagging>(); // FIXME
+}
+
+} // detail
+
+bool custom_tags_api::is_tagged( const std::string& user, const std::string& tagged_by, const std::string& tag ) const
+{
+   return my->is_tagged( user, tagged_by, tag );
+}
+
+const fc::optional<std::set<std::string>>& custom_tags_api::list_checked_tags()const
+{
+   return my->list_checked_tags();
+}
+
+const fc::optional<std::set<std::string>>& custom_tags_api::list_checked_taggers()const
+{
+   return my->list_checked_taggers();
+}
+
+std::vector<tagging> custom_tags_api::list_tags( const std::string& filter_tagger,
+                                      const std::string& filter_tag,
+                                      const std::string& filter_taggee,
+                                      const std::string& start_tagger,
+                                      const std::string& start_tag,
+                                      const std::string& start_taggee )const
+{
+    return my->list_tags( filter_tagger, filter_tag, filter_taggee,
+                          start_tagger, start_tag, start_taggee );
+}
+
+custom_tags_api::custom_tags_api( const muse::app::api_context& ctx )
+{
+   my = std::make_shared< detail::custom_tags_api_impl >( ctx.app );
+}
+
+void custom_tags_api::on_api_startup() {}
+
+tagging::tagging( const tag_object& t )
+   : tagger(t.tagger), tag(t.tag), taggee(t.taggee) {}
+
+} } // muse::custom_tags

--- a/libraries/plugins/custom_tags/custom_tags_api.cpp
+++ b/libraries/plugins/custom_tags/custom_tags_api.cpp
@@ -41,8 +41,8 @@ public:
    }
 
    bool is_tagged( const std::string& user, const std::string& tagged_by, const std::string& tag ) const;
-   const fc::optional<std::set<std::string>>& list_checked_tags()const;
-   const fc::optional<std::set<std::string>>& list_checked_taggers()const;
+//   const fc::optional<std::set<std::string>>& list_checked_tags()const;
+//   const fc::optional<std::set<std::string>>& list_checked_taggers()const;
    std::vector<half_tagging> list_tags_from( const std::string& tagger,
                                              const std::string& filter_tag,
                                              const std::string& start_tag,
@@ -62,17 +62,17 @@ bool custom_tags_api_impl::is_tagged( const std::string& user, const std::string
    return idx.find( boost::make_tuple( tagged_by, tag, user ) ) != idx.end();
 }
 
-static const fc::optional<std::set<std::string>> EMPTY;
+//static const fc::optional<std::set<std::string>> EMPTY;
 
-const fc::optional<std::set<std::string>>& custom_tags_api_impl::list_checked_tags()const
-{
-   return EMPTY; // FIXME
-}
-
-const fc::optional<std::set<std::string>>& custom_tags_api_impl::list_checked_taggers()const
-{
-   return EMPTY; // FIXME
-}
+//const fc::optional<std::set<std::string>>& custom_tags_api_impl::list_checked_tags()const
+//{
+//   return EMPTY; // FIXME
+//}
+//
+//const fc::optional<std::set<std::string>>& custom_tags_api_impl::list_checked_taggers()const
+//{
+//   return EMPTY; // FIXME
+//}
 
 std::vector<half_tagging> custom_tags_api_impl::list_tags_from( const std::string& tagger,
                                                                 const std::string& filter_tag,
@@ -119,15 +119,15 @@ bool custom_tags_api::is_tagged( const std::string& user, const std::string& tag
    return my->is_tagged( user, tagged_by, tag );
 }
 
-const fc::optional<std::set<std::string>>& custom_tags_api::list_checked_tags()const
-{
-   return my->list_checked_tags();
-}
-
-const fc::optional<std::set<std::string>>& custom_tags_api::list_checked_taggers()const
-{
-   return my->list_checked_taggers();
-}
+//const fc::optional<std::set<std::string>>& custom_tags_api::list_checked_tags()const
+//{
+//   return my->list_checked_tags();
+//}
+//
+//const fc::optional<std::set<std::string>>& custom_tags_api::list_checked_taggers()const
+//{
+//   return my->list_checked_taggers();
+//}
 
 std::vector<half_tagging> custom_tags_api::list_tags_from( const std::string& tagger,
                                                            const std::string& filter_tag,

--- a/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags.hpp
+++ b/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags.hpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2018 Peertracks, Inc., and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+#include <muse/app/plugin.hpp>
+#include <muse/chain/database.hpp>
+
+#include <graphene/db/generic_index.hpp>
+
+#include <boost/multi_index/composite_key.hpp>
+
+//
+// Plugins should #define their SPACE_ID's so plugins with
+// conflicting SPACE_ID assignments can be compiled into the
+// same binary (by simply re-assigning some of the conflicting #defined
+// SPACE_ID's in a build script).
+//
+// Assignment of SPACE_ID's cannot be done at run-time because
+// various template automagic depends on them being known at compile
+// time.
+//
+#ifndef CUSTOM_TAGS_SPACE_ID
+#define CUSTOM_TAGS_SPACE_ID 8
+#endif
+
+namespace muse { namespace custom_tags {
+
+using namespace graphene::db;
+
+namespace detail {
+   class custom_tags_impl;
+}
+
+class custom_tags_plugin : public muse::app::plugin {
+   public:
+      custom_tags_plugin();
+      ~custom_tags_plugin();
+
+      std::string plugin_name()const override;
+
+      virtual void plugin_set_program_options(
+         boost::program_options::options_description &command_line_options,
+         boost::program_options::options_description &config_file_options
+      ) override;
+
+      virtual void plugin_initialize( const boost::program_options::variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
+
+   private:
+      std::unique_ptr<detail::custom_tags_impl> my;
+};
+
+struct tag_object : public graphene::db::abstract_object< tag_object > {
+   static const uint8_t space_id = CUSTOM_TAGS_SPACE_ID;
+   static const uint8_t type_id = 1;
+
+   std::string tagger;
+   std::string tag;
+   std::string taggee;
+};
+
+typedef boost::multi_index_container<
+   tag_object,
+   indexed_by<
+      ordered_unique< tag< by_id >, member< object, object_id_type, &object::id > >
+   >
+> custom_tags_multi_index_container;
+typedef generic_index<tag_object, custom_tags_multi_index_container> custom_tags_index;
+
+} } // muse::custom_tags
+
+FC_REFLECT_DERIVED( muse::custom_tags::tag_object, (graphene::db::object),
+                    (tagger)(tag)(taggee) )

--- a/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags.hpp
+++ b/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags.hpp
@@ -81,16 +81,22 @@ struct tag_object : public graphene::db::abstract_object< tag_object > {
    std::string taggee;
 };
 
-struct by_all;
+struct by_tagger;
+struct by_taggee;
 typedef boost::multi_index_container<
    tag_object,
    indexed_by<
       ordered_unique< tag< by_id >, member< object, object_id_type, &object::id > >,
-      ordered_unique< tag< by_all >,
+      ordered_unique< tag< by_tagger >,
          composite_key< tag_object,
                         member< tag_object, std::string, &tag_object::tagger >,
                         member< tag_object, std::string, &tag_object::tag >,
-                        member< tag_object, std::string, &tag_object::taggee > > >
+                        member< tag_object, std::string, &tag_object::taggee > > >,
+      ordered_unique< tag< by_taggee >,
+         composite_key< tag_object,
+                        member< tag_object, std::string, &tag_object::taggee >,
+                        member< tag_object, std::string, &tag_object::tag >,
+                        member< tag_object, std::string, &tag_object::tagger > > >
    >
 > custom_tags_multi_index_container;
 typedef generic_index<tag_object, custom_tags_multi_index_container> custom_tags_index;

--- a/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags.hpp
+++ b/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags.hpp
@@ -81,10 +81,16 @@ struct tag_object : public graphene::db::abstract_object< tag_object > {
    std::string taggee;
 };
 
+struct by_all;
 typedef boost::multi_index_container<
    tag_object,
    indexed_by<
-      ordered_unique< tag< by_id >, member< object, object_id_type, &object::id > >
+      ordered_unique< tag< by_id >, member< object, object_id_type, &object::id > >,
+      ordered_unique< tag< by_all >,
+         composite_key< tag_object,
+                        member< tag_object, std::string, &tag_object::tagger >,
+                        member< tag_object, std::string, &tag_object::tag >,
+                        member< tag_object, std::string, &tag_object::taggee > > >
    >
 > custom_tags_multi_index_container;
 typedef generic_index<tag_object, custom_tags_multi_index_container> custom_tags_index;

--- a/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags_api.hpp
+++ b/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags_api.hpp
@@ -39,13 +39,12 @@ namespace detail {
    class custom_tags_api_impl;
 }
 
-class tagging {
+class half_tagging {
 public:
-   tagging( const tag_object& t );
+   half_tagging( const tag_object& t, bool use_tagger );
 
-   std::string tagger;
+   std::string user;
    std::string tag;
-   std::string taggee;
 };
 
 class custom_tags_api
@@ -75,31 +74,41 @@ class custom_tags_api
       const fc::optional<std::set<std::string>>& list_checked_taggers()const;
 
       /**
-       * @brief Returns a possibly filtered list of up to 100 known tags, ordered by (tagger,tag,taggee)
-       * @param filter_tagger only return tags set by this user, or empty string
+       * @brief Returns a possibly filtered list of up to 100 known tags, ordered by (tag,taggee)
+       * @param tagger the creator of the tags to return
        * @param filter_tag only return tags with this value, or empty string
-       * @param filter_taggee only return tags set on this user, or empty string
-       * @param start_tagger start with tags set by this user, or empty string
        * @param start_tag start with tags containing this value, or empty string
        * @param start_taggee start with tags set on this user, or empty string
        */
-      std::vector<tagging> list_tags( const std::string& filter_tagger,
-                                      const std::string& filter_tag,
-                                      const std::string& filter_taggee,
-                                      const std::string& start_tagger,
-                                      const std::string& start_tag,
-                                      const std::string& start_taggee )const;
+      std::vector<half_tagging> list_tags_from( const std::string& tagger,
+                                                const std::string& filter_tag,
+                                                const std::string& start_tag,
+                                                const std::string& start_taggee )const;
+
+      /**
+       * @brief Returns a possibly filtered list of up to 100 known tags, ordered by (tag,tagger)
+       * @param taggee the recipient of the tags to return
+       * @param filter_tag only return tags with this value, or empty string
+       * @param start_tag start with tags containing this value, or empty string
+       * @param start_tagger start with tags set by this user, or empty string
+       */
+      std::vector<half_tagging> list_tags_on( const std::string& taggee,
+                                              const std::string& filter_tag,
+                                              const std::string& start_tag,
+                                              const std::string& start_tagger )const;
+
    private:
       std::shared_ptr< detail::custom_tags_api_impl > my;
 };
 
 } } // muse::custom_tags
 
-FC_REFLECT( muse::custom_tags::tagging, (tagger)(tag)(taggee) )
+FC_REFLECT( muse::custom_tags::half_tagging, (user)(tag) )
 
 FC_API( muse::custom_tags::custom_tags_api,
         (is_tagged)
         (list_checked_tags)
         (list_checked_taggers)
-        (list_tags)
+        (list_tags_from)
+        (list_tags_on)
       )

--- a/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags_api.hpp
+++ b/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags_api.hpp
@@ -66,12 +66,12 @@ class custom_tags_api
       /**
        * @brief Returns a list of all tags checked by this node, or null if it handles all tags
        */
-      const fc::optional<std::set<std::string>>& list_checked_tags()const;
+      //const fc::optional<std::set<std::string>>& list_checked_tags()const;
 
       /**
        * @brief Returns a list of all taggers checked by this node, or null if it handles all taggers
        */
-      const fc::optional<std::set<std::string>>& list_checked_taggers()const;
+      //const fc::optional<std::set<std::string>>& list_checked_taggers()const;
 
       /**
        * @brief Returns a possibly filtered list of up to 100 known tags, ordered by (tag,taggee)
@@ -107,8 +107,8 @@ FC_REFLECT( muse::custom_tags::half_tagging, (user)(tag) )
 
 FC_API( muse::custom_tags::custom_tags_api,
         (is_tagged)
-        (list_checked_tags)
-        (list_checked_taggers)
+//        (list_checked_tags)
+//        (list_checked_taggers)
         (list_tags_from)
         (list_tags_on)
       )

--- a/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags_api.hpp
+++ b/libraries/plugins/custom_tags/include/muse/custom_tags/custom_tags_api.hpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018 PeerTracks, Inc., and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+#include <muse/custom_tags/custom_tags.hpp>
+
+#include <muse/chain/protocol/types.hpp>
+
+#include <fc/api.hpp>
+
+namespace muse { namespace app {
+   struct api_context;
+} }
+
+namespace muse { namespace custom_tags {
+
+namespace detail {
+   class custom_tags_api_impl;
+}
+
+class tagging {
+public:
+   tagging( const tag_object& t );
+
+   std::string tagger;
+   std::string tag;
+   std::string taggee;
+};
+
+class custom_tags_api
+{
+   public:
+      custom_tags_api( const muse::app::api_context& ctx );
+
+      void on_api_startup();
+
+      /**
+       * @brief Checks if the given user has received the given tagged from the tagged_by user
+       * @param user the user who might have been tagged
+       * @param tagged_by the user who might have tagged "user"
+       * @param the tag to check for
+       * @return true iff we know that "tagged_by" has tagged "user" with "tag"
+       */
+      bool is_tagged( const std::string& user, const std::string& tagged_by, const std::string& tag ) const;
+
+      /**
+       * @brief Returns a list of all tags checked by this node, or null if it handles all tags
+       */
+      const fc::optional<std::set<std::string>>& list_checked_tags()const;
+
+      /**
+       * @brief Returns a list of all taggers checked by this node, or null if it handles all taggers
+       */
+      const fc::optional<std::set<std::string>>& list_checked_taggers()const;
+
+      /**
+       * @brief Returns a possibly filtered list of up to 100 known tags, ordered by (tagger,tag,taggee)
+       * @param filter_tagger only return tags set by this user, or empty string
+       * @param filter_tag only return tags with this value, or empty string
+       * @param filter_taggee only return tags set on this user, or empty string
+       * @param start_tagger start with tags set by this user, or empty string
+       * @param start_tag start with tags containing this value, or empty string
+       * @param start_taggee start with tags set on this user, or empty string
+       */
+      std::vector<tagging> list_tags( const std::string& filter_tagger,
+                                      const std::string& filter_tag,
+                                      const std::string& filter_taggee,
+                                      const std::string& start_tagger,
+                                      const std::string& start_tag,
+                                      const std::string& start_taggee )const;
+   private:
+      std::shared_ptr< detail::custom_tags_api_impl > my;
+};
+
+} } // muse::custom_tags
+
+FC_REFLECT( muse::custom_tags::tagging, (tagger)(tag)(taggee) )
+
+FC_API( muse::custom_tags::custom_tags_api,
+        (is_tagged)
+        (list_checked_tags)
+        (list_checked_taggers)
+        (list_tags)
+      )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,11 +8,11 @@ endif()
 
 file(GLOB UNIT_TESTS "tests/*.cpp")
 add_executable( chain_test ${UNIT_TESTS} ${COMMON_SOURCES} )
-target_link_libraries( chain_test muse_chain muse_app muse_egenesis_full muse_account_history muse_market_history graphene_utilities fc ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chain_test muse_chain muse_app muse_egenesis_full muse_account_history muse_market_history muse_custom_tags graphene_utilities fc ${PLATFORM_SPECIFIC_LIBS} )
 
 file(GLOB PLUGIN_TESTS "plugin_tests/*.cpp")
 add_executable( plugin_test ${PLUGIN_TESTS} ${COMMON_SOURCES} )
-target_link_libraries( plugin_test muse_chain muse_app muse_account_history muse_egenesis_full muse_market_history muse_egenesis_full fc ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( plugin_test muse_chain muse_app muse_account_history muse_egenesis_full muse_market_history muse_custom_tags muse_egenesis_full fc ${PLATFORM_SPECIFIC_LIBS} )
 
 if(MSVC)
   set_source_files_properties( tests/serialization_tests.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -8,6 +8,7 @@
 #include <muse/chain/base_objects.hpp>
 #include <muse/chain/history_object.hpp>
 #include <muse/account_history/account_history_plugin.hpp>
+#include <muse/custom_tags/custom_tags.hpp>
 
 #include <fc/crypto/digest.hpp>
 #include <fc/smart_ref_impl.hpp>
@@ -41,6 +42,7 @@ clean_database_fixture::clean_database_fixture()
          std::cout << "running test " << boost::unit_test::framework::current_test_case().p_name << std::endl;
    }
    auto ahplugin = app.register_plugin< muse::account_history::account_history_plugin >();
+   auto ctplugin = app.register_plugin< muse::custom_tags::custom_tags_plugin >();
    init_account_pub_key = init_account_priv_key.get_public_key();
 
    boost::program_options::variables_map options;
@@ -49,7 +51,9 @@ clean_database_fixture::clean_database_fixture()
 
    // app.initialize();
    ahplugin->plugin_set_app( &app );
+   ctplugin->plugin_set_app( &app );
    ahplugin->plugin_initialize( options );
+   ctplugin->plugin_initialize( options );
 
    validate_database();
    generate_block();

--- a/tests/plugin_tests/custom_tags.cpp
+++ b/tests/plugin_tests/custom_tags.cpp
@@ -24,6 +24,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <muse/app/api_context.hpp>
+
 #include <muse/chain/protocol/base_operations.hpp>
 
 #include <muse/custom_tags/custom_tags_api.hpp>
@@ -37,7 +39,7 @@ BOOST_FIXTURE_TEST_SUITE( custom_tags, clean_database_fixture );
 
 BOOST_AUTO_TEST_CASE( simple_test )
 { try {
-   ACTORS( (alice)(brenda)(tess) );
+   ACTORS( (alice)(brenda)(tamara)(tess) );
 
    generate_block();
 
@@ -144,23 +146,160 @@ BOOST_AUTO_TEST_CASE( simple_test )
    trx.clear();
    BOOST_CHECK( idx.empty() );
 
+   cop.json = "{\"label\":\"x\",\"set\":[\"zarah\"]}"; // unknown user
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"x\",\"add\":[\"zarah\"]}"; // unknown user
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"x\",\"remove\":[\"zarah\"]}"; // unknown user
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.required_auths.insert( "tess" ); // too many taggers
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.required_auths.insert( "tamara" ); // too many taggers
+   cop.required_basic_auths.clear();
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.required_basic_auths.insert( "tamara" ); // too many taggers
+   cop.required_basic_auths.insert( "tess" );
+   cop.required_auths.clear();
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.required_basic_auths.clear();
+   cop.required_basic_auths.insert( "tess" );
    cop.json = "{\"label\":\"x\",\"set\":[\"alice\"]}"; // works
    trx.operations.push_back( cop );
    PUSH_TX( db, trx, database::skip_transaction_signatures );
    trx.clear();
    BOOST_CHECK_EQUAL( 1, idx.size() );
 
+   cop.required_basic_auths.clear();
+   cop.required_auths.insert( "tamara" );
    cop.json = "{\"label\":\"x\",\"add\":[\"brenda\"]}"; // works
    trx.operations.push_back( cop );
    PUSH_TX( db, trx, database::skip_transaction_signatures );
    trx.clear();
    BOOST_CHECK_EQUAL( 2, idx.size() );
 
+   cop.required_auths.clear();
+   cop.required_basic_auths.insert( "tess" );
    cop.json = "{\"label\":\"x\",\"remove\":[\"alice\"]}"; // works
    trx.operations.push_back( cop );
    PUSH_TX( db, trx, database::skip_transaction_signatures );
    trx.clear();
    BOOST_CHECK_EQUAL( 1, idx.size() );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_CASE( api_test )
+{ try {
+   ACTORS( (alice)(brenda)(charlene)(dora)(tamara)(tess) );
+
+   generate_block();
+
+   const auto& idx = db.get_index_type<muse::custom_tags::custom_tags_index>().indices().get<muse::custom_tags::by_tagger>();
+   custom_json_operation cop;
+
+   cop.required_auths.insert( "tamara" );
+   cop.json = "{\"label\":\"abc\",\"set\":[\"alice\",\"brenda\"]}";
+   trx.operations.push_back( cop );
+   cop.json = "{\"label\":\"test\",\"add\":[\"charlene\",\"brenda\"]}";
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK_EQUAL( 4, idx.size() );
+
+   cop.required_basic_auths.insert( "tess" );
+   cop.required_auths.clear();
+   cop.json = "{\"label\":\"abc\",\"set\":[\"alice\",\"brenda\"]}";
+   trx.operations.push_back( cop );
+   cop.json = "{\"label\":\"bad girl\",\"add\":[\"dora\"]}";
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK_EQUAL( 7, idx.size() );
+
+
+   //muse::custom_tags::custom_tags_api& api = *reinterpret_cast<muse::custom_tags::custom_tags_api*>(app.create_api_by_name( muse::app::api_context( app, "custom_tags", std::weak_ptr<muse::app::api_session_data>(std::shared_ptr<muse::app::api_session_data>(nullptr)) ) )->as<fc::api<muse::custom_tags::custom_tags_api>>().get_handle());
+   muse::custom_tags::custom_tags_api api( muse::app::api_context( app, "custom_tags", std::weak_ptr<muse::app::api_session_data>(std::shared_ptr<muse::app::api_session_data>(nullptr)) ) );
+
+   BOOST_CHECK( api.is_tagged( "alice", "tamara", "abc" ) );
+   BOOST_CHECK( api.is_tagged( "brenda", "tamara", "abc" ) );
+   BOOST_CHECK( api.is_tagged( "charlene", "tamara", "test" ) );
+   BOOST_CHECK( api.is_tagged( "brenda", "tamara", "test" ) );
+   BOOST_CHECK( !api.is_tagged( "charlene", "tamara", "abc" ) );
+   BOOST_CHECK( !api.is_tagged( "alice", "tamara", "test" ) );
+
+   BOOST_CHECK( api.is_tagged( "alice", "tess", "abc" ) );
+   BOOST_CHECK( api.is_tagged( "brenda", "tess", "abc" ) );
+   BOOST_CHECK( api.is_tagged( "dora", "tess", "bad girl" ) );
+   BOOST_CHECK( !api.is_tagged( "dora", "tess", "abc" ) );
+   BOOST_CHECK( !api.is_tagged( "alice", "tess", "bad girl" ) );
+   BOOST_CHECK( !api.is_tagged( "brenda", "tess", "bad girl" ) );
+
+
+   auto list = api.list_tags_from( "tamara", "", "", "" );
+   BOOST_REQUIRE_EQUAL( 4, list.size() );
+   BOOST_CHECK_EQUAL( "abc", list[0].tag );
+   BOOST_CHECK_EQUAL( "alice", list[0].user );
+   BOOST_CHECK_EQUAL( "abc", list[1].tag );
+   BOOST_CHECK_EQUAL( "brenda", list[1].user );
+   BOOST_CHECK_EQUAL( "test", list[2].tag );
+   BOOST_CHECK_EQUAL( "brenda", list[2].user );
+   BOOST_CHECK_EQUAL( "test", list[3].tag );
+   BOOST_CHECK_EQUAL( "charlene", list[3].user );
+
+   list = api.list_tags_from( "tamara", "test", "", "" );
+   BOOST_REQUIRE_EQUAL( 2, list.size() );
+   BOOST_CHECK_EQUAL( "test", list[0].tag );
+   BOOST_CHECK_EQUAL( "brenda", list[0].user );
+   BOOST_CHECK_EQUAL( "test", list[1].tag );
+   BOOST_CHECK_EQUAL( "charlene", list[1].user );
+
+   list = api.list_tags_from( "tamara", "", "abc", "brenda" );
+   BOOST_REQUIRE_EQUAL( 3, list.size() );
+
+   list = api.list_tags_from( "tamara", "", "zak", "" );
+   BOOST_CHECK( list.empty() );
+
+   list = api.list_tags_from( "alice", "", "", "" );
+   BOOST_CHECK( list.empty() );
+
+
+   list = api.list_tags_on( "alice", "", "", "" );
+   BOOST_REQUIRE_EQUAL( 2, list.size() );
+   BOOST_CHECK_EQUAL( "abc", list[0].tag );
+   BOOST_CHECK_EQUAL( "tamara", list[0].user );
+   BOOST_CHECK_EQUAL( "abc", list[1].tag );
+   BOOST_CHECK_EQUAL( "tess", list[1].user );
+
+   list = api.list_tags_on( "brenda", "bad girl", "", "" );
+   BOOST_CHECK( list.empty() );
+
+   list = api.list_tags_on( "brenda", "", "bad girl", "" );
+   BOOST_CHECK_EQUAL( 1, list.size() );
+   BOOST_CHECK_EQUAL( "test", list[0].tag );
+   BOOST_CHECK_EQUAL( "tamara", list[0].user );
+
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/plugin_tests/custom_tags.cpp
+++ b/tests/plugin_tests/custom_tags.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2018 Peertracks, Inc., and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <muse/chain/protocol/base_operations.hpp>
+
+#include <muse/custom_tags/custom_tags_api.hpp>
+
+#include "../common/database_fixture.hpp"
+
+using namespace muse::chain;
+using namespace muse::chain::test;
+
+BOOST_FIXTURE_TEST_SUITE( custom_tags, clean_database_fixture );
+
+BOOST_AUTO_TEST_CASE( simple_test )
+{ try {
+   ACTORS( (alice)(brenda)(tess) );
+
+   generate_block();
+
+   const auto& idx = db.get_index_type<muse::custom_tags::custom_tags_index>().indices().get<muse::custom_tags::by_tagger>();
+
+   trx.set_expiration( db.head_block_time() + MUSE_MAX_TIME_UNTIL_EXPIRATION );
+
+   custom_json_operation cop;
+   cop.required_basic_auths.insert( "tess" );
+
+   cop.json = "1"; // not an object
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "\"hello\""; // not an object
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "[]"; // not an object
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "true"; // not an object
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{}"; // missing label
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":{}, \"set\":[\"alice\"]}"; // label is not a string
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":1, \"set\":[\"alice\"]}"; // label is not a string
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":false, \"set\":[\"alice\"]}"; // label is not a string
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"test\"}"; // missing set/add/remove
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"test\", \"set\":{}}"; // set is not an array
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"test\", \"set\":1}"; // set is not an array
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"test\", \"set\":\"alice\"}"; // set is not an array
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"test\", \"set\":[]}"; // set is empty
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"set\":[\"alice\"]}"; // missing label
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"test\", \"set\":[\"alice\"], \"add\":[\"brenda\"]}"; // set and add
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"test\", \"set\":[\"alice\"], \"remove\":[\"brenda\"]}"; // set and remove
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK( idx.empty() );
+
+   cop.json = "{\"label\":\"x\",\"set\":[\"alice\"]}"; // works
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK_EQUAL( 1, idx.size() );
+
+   cop.json = "{\"label\":\"x\",\"add\":[\"brenda\"]}"; // works
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK_EQUAL( 2, idx.size() );
+
+   cop.json = "{\"label\":\"x\",\"remove\":[\"alice\"]}"; // works
+   trx.operations.push_back( cop );
+   PUSH_TX( db, trx, database::skip_transaction_signatures );
+   trx.clear();
+   BOOST_CHECK_EQUAL( 1, idx.size() );
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Resolves #93 

The plugin will use custom_json operations if
* there is only only signing authority, either basic or active
* the json contains a "label" field with a string label
* the json contains
** either a "set" field with an array of usernames, or
** an "add" field and/or a "remove" field which are also arrays of usernames

The plugin also provides API methods to query
* if a given account has added a label (aka tag) for another account
* the list of tags set by a given account
* the list of tags set (by others) on a given account
