### PR TITLE
move check before push

### DIFF
--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -2640,11 +2640,6 @@ namespace graphene { namespace net { namespace detail {
           if (!item_hashes_received.empty() && !originating_peer->ids_of_items_to_get.empty())
             assert(item_hashes_received.front() != originating_peer->ids_of_items_to_get.back());
 
-          // append the remaining items to the peer's list
-          boost::push_back(originating_peer->ids_of_items_to_get, item_hashes_received);
-
-          originating_peer->number_of_unfetched_item_ids = blockchain_item_ids_inventory_message_received.total_remaining_item_count;
-
           // at any given time, there's a maximum number of blocks that can possibly be out there
           // [(now - genesis time) / block interval].  If they offer us more blocks than that,
           // they must be an attacker or have a buggy client.
@@ -2665,6 +2660,11 @@ namespace graphene { namespace net { namespace detail {
                                  true, error_for_peer);
             return;
           }
+
+          // append the remaining items to the peer's list
+          boost::push_back(originating_peer->ids_of_items_to_get, item_hashes_received);
+
+          originating_peer->number_of_unfetched_item_ids = blockchain_item_ids_inventory_message_received.total_remaining_item_count;
 
           uint32_t new_number_of_unfetched_items = calculate_unsynced_block_count_from_all_peers();
           if (new_number_of_unfetched_items != _total_number_of_unfetched_items)

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -2664,8 +2664,6 @@ namespace graphene { namespace net { namespace detail {
           // append the remaining items to the peer's list
           boost::push_back(originating_peer->ids_of_items_to_get, item_hashes_received);
 
-          originating_peer->number_of_unfetched_item_ids = blockchain_item_ids_inventory_message_received.total_remaining_item_count;
-
           uint32_t new_number_of_unfetched_items = calculate_unsynced_block_count_from_all_peers();
           if (new_number_of_unfetched_items != _total_number_of_unfetched_items)
             _delegate->sync_status(blockchain_item_ids_inventory_message_received.item_type,


### PR DESCRIPTION
cherry picked first but found there are a few differences with the bitshares core inside the check like `MUSE_BLOCK_INTERVAL` and `_delegate->get_blockchain_now()` so decided to make new commit with the spirit. Spirit is actually move the check before the push, this pull moves the MUSE check instead of cherry picking from bitshares.

tried a replay and found this issue when doing so: https://github.com/themuseblockchain/Muse-Source/issues/128




